### PR TITLE
fix(kuma-cp): don't let CA requests for other meshes block generation…

### DIFF
--- a/api/mesh/v1alpha1/mesh.pb.go
+++ b/api/mesh/v1alpha1/mesh.pb.go
@@ -1198,6 +1198,7 @@ type CertificateAuthorityBackend_RootChain struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Timeout on request for to CA for root certificate chain.
+	// If not specified, defaults to 10s.
 	RequestTimeout *durationpb.Duration `protobuf:"bytes,1,opt,name=requestTimeout,proto3" json:"requestTimeout,omitempty"`
 }
 

--- a/api/mesh/v1alpha1/mesh.proto
+++ b/api/mesh/v1alpha1/mesh.proto
@@ -146,6 +146,7 @@ message CertificateAuthorityBackend {
   // RootChain defines settings related to CA root certificate chain.
   message RootChain {
     // Timeout on request for to CA for root certificate chain.
+    // If not specified, defaults to 10s.
     google.protobuf.Duration requestTimeout = 1;
   }
 

--- a/docs/generated/resources/other_mesh.md
+++ b/docs/generated/resources/other_mesh.md
@@ -56,6 +56,7 @@
             - `requestTimeout` (optional)
             
                 Timeout on request for to CA for root certificate chain.
+                If not specified, defaults to 10s.
 
 - `tracing` (optional)
 
@@ -250,6 +251,7 @@
     - `requestTimeout` (optional)
     
         Timeout on request for to CA for root certificate chain.
+        If not specified, defaults to 10s.
 ## Networking
 
 - `outbound` (optional)


### PR DESCRIPTION
… (#6282)

This PR adds a default timeout of 10s to calls of GetRootCert for the case that the CA manager takes too long, so that it doesn't block generation, especially in the cross-mesh case.

### Checklist prior to review

<!--
Each of these sections need to be filled by the author when opening the PR.

If something doesn't apply please check the box and add a justification after the `--`
-->

- [ ] [Link to relevant issue][1] as well as docs and UI issues --
- [ ] This will not break child repos: it doesn't hardcode values (.e.g "kumahq" as a image registry) and it will work on Windows, system specific functions like `syscall.Mkfifo` have equivalent implementation on the other OS --
- [ ] Tests (Unit test, E2E tests, manual test on universal and k8s) --
- [ ] Do you need to update [`UPGRADE.md`](../blob/master/UPGRADE.md)? --
- [ ] Does it need to be backported according to the [backporting policy](../blob/master/CONTRIBUTING.md#backporting)? --
- [ ] Do you need to explicitly set a [`> Changelog:` entry here](../blob/master/CONTRIBUTING.md#submitting-a-patch) or add a `ci/` label to run fewer/more tests?

[1]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
